### PR TITLE
Update CMAKE_MODULE_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ option(BOOST_DOWNLOAD_TO_BINARY_DIR "Prefer downloading Boost to the binary dire
 set(BOOST_URL "http://downloads.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.7z")
 set(BOOST_URL_SHA256 "25db3956a8d58187ac7a0702cc917e9bab47ff90baafc35e4e789dca1ce5f423")
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL "${CMAKE_SOURCE_DIR}")
   message("-- Standalone mode detected")


### PR DESCRIPTION
this should allow the script to find the correct module path even when being called externally