### PR TITLE
Allow a local directory to be specified for finding boost archives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(Boost-CMake)
 option(BOOST_DOWNLOAD_TO_BINARY_DIR "Prefer downloading Boost to the binary directory instead of source directory" OFF)
 set(BOOST_URL "https://github.com/Orphis/boost-cmake/releases/download/v1.64.0/boost_1_64_0.tar.xz" CACHE STRING "Boost download URL")
 set(BOOST_URL_SHA256 "d964dfdab2f73d04a8f52303f1b141344447b78ab85dc79da78fa167fdd807f5" CACHE STRING "Boost download URL SHA256 checksum")
+set(BOOST_ARCHIVE_DIRECTORY "" CACHE DIRECTORY "Use the specified local directory to search for boost archives instead of downloading them" )
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
 


### PR DESCRIPTION
Per the commit message:

```
Allow using a local directory to find boost archives

Instead of downloading boost, allow the user to specify the path to a directory
that contains the required boost archive. To specify this archive directory, use
the new BOOST_ARCHIVE_DIRECTORY cache option. It must point to a valid, existing
directory on the filesystem. To instead download the archives normally, simply
set BOOST_ARCHIVE_DIRECTORY to an empty string or delete it entirely.

When a local directory for archives is being used, any SHA mismatch or missing
archive file will result in permanent failure. In other words, boost will not be
downloaded if these checks fail.

```