### PR TITLE
User defined libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ set(BOOST_LIBS_OPTIONAL
   timer
   type_erasure
   wave
+  CACHE STRING ""  
 )
 
 foreach(lib ${BOOST_LIBS_REQUIRED})

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ set(BOOST_SOURCE /path/to/boost)
 add_subdirectory(boost-cmake)
 ```
 
+You can specify a subset of compiled libraries, which will be included to project. This can be useful for a build with MSVC compiler.
+'''
+set(BOOST_LIBS_OPTIONAL filesystem program_options system CACHE STRING "" FORCE)
+add_subdirectory(boost-cmake)
+'''
+
 ## Motivation
 
 Most people struggle building Boost for various platforms or using package managers to get the right version, so I figured I would open-source the solution similar to the one I developed while I worked at Spotify.

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ add_subdirectory(boost-cmake)
 ```
 
 You can specify a subset of compiled libraries, which will be included to project. This can be useful for a build with MSVC compiler.
-'''
+```
 set(BOOST_LIBS_OPTIONAL filesystem program_options system CACHE STRING "" FORCE)
 add_subdirectory(boost-cmake)
-'''
+```
 
 ## Motivation
 


### PR DESCRIPTION
Support for a user-defined subset of BOOST_LIBS_OPTIONAL.
Motivation:
Under MSVC all libraries from BOOST_LIBS_OPTIONAL automatically added to the workspace as subprojects. This does not depend from cmake directives "target_link_libraries".
And this leads to long compilation time, even if only one library from Boost used.
Solution:
USe SET directive for BOOST_LIBS_OPTIONAL with CACHE option.
As result, a top-level code can predefine the list of libraries.

