### PR TITLE
CMake: Add cache option to disable building of test targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.0.0)
 project(Boost-CMake)
 
 option(BOOST_DOWNLOAD_TO_BINARY_DIR "Prefer downloading Boost to the binary directory instead of source directory" OFF)
+option(BOOST_DISABLE_TESTS "Do not build test targets, even if building standalone" OFF)
+
 set(BOOST_URL "https://github.com/Orphis/boost-cmake/releases/download/v1.67.0/boost_1_67_0.tar.xz" CACHE STRING "Boost download URL")
 set(BOOST_URL_SHA256 "4256a98911fbc943f7d97aab5f14f2ecde5341d90c5c5441696b7d99425af8fd" CACHE STRING "Boost download URL SHA256 checksum")
 set(BOOST_ARCHIVE_DIRECTORY "" CACHE DIRECTORY "Use the specified local directory to search for boost archives instead of downloading them" )

--- a/cmake/Modules/AddBoostTest.cmake
+++ b/cmake/Modules/AddBoostTest.cmake
@@ -1,5 +1,5 @@
 function(_add_boost_test)
-  if(NOT BOOST_STANDALONE)
+  if(NOT BOOST_STANDALONE OR BOOST_DISABLE_TESTS)
     return()
   endif()
 


### PR DESCRIPTION
The `BOOST_DISABLE_TESTS` option (disabled by default) controls whether or
not the test targets should be generated by CMake. Enabling this is useful
in cases where you just want to build boost and install it, without incurring
the additional overhead (build time) of building the tests.