### PR TITLE
fix mpi cmp0004 error

### DIFF
--- a/libs/mpi.cmake
+++ b/libs/mpi.cmake
@@ -29,4 +29,6 @@ _add_boost_lib(
     Boost::serialization
 )
 target_include_directories(Boost_mpi PUBLIC ${MPI_CXX_INCLUDE_PATH})
+string(STRIP "${MPI_CXX_LINK_FLAGS}" MPI_CXX_LINK_FLAGS)
+string(STRIP "${MPI_CXX_LIBRARIES}" MPI_CXX_LIBRARIES)
 target_link_libraries(Boost_mpi PUBLIC ${MPI_CXX_LINK_FLAGS} ${MPI_CXX_LIBRARIES})


### PR DESCRIPTION
>CMake Error at cmake/Modules/AddBoostLib.cmake:7 (add_library):
  Target "Boost_mpi" links to item " -Wl,-rpath -Wl,/usr/lib/openmpi/lib
  -Wl,--enable-new-dtags" which has leading or trailing whitespace.  This is
  now an error according to policy CMP0004.

cmake version 3.5.1 on ubuntu xenial
