### PR TITLE
Fixed CMake Warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.0.0)
 project(Boost-CMake)
 
+cmake_policy(SET CMP0074 NEW)
+
 option(BOOST_DOWNLOAD_TO_BINARY_DIR "Prefer downloading Boost to the binary directory instead of source directory" OFF)
 option(BOOST_DISABLE_TESTS "Do not build test targets, even if building standalone" OFF)
 


### PR DESCRIPTION
Before it was showing this:
```
CMake Warning (dev) at boost-cmake/libs/iostreams.cmake:26 (find_package):
  Policy CMP0074 is not set: find_package uses <PackageName>_ROOT variables.
  Run "cmake --help-policy CMP0074" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  CMake variable ZLIB_ROOT is set to:

    zlib

  For compatibility, CMake is ignoring the variable.
```