### PR TITLE
Fix issue with -isystem when compiling swift code.

### DIFF
--- a/libs/header.cmake
+++ b/libs/header.cmake
@@ -1,12 +1,7 @@
 # Define the header-only Boost target
 add_library(Boost::boost INTERFACE IMPORTED GLOBAL)
-if(CMAKE_GENERATOR MATCHES "Xcode")
-  # The CMake Xcode generator doesn't support system headers directly
-  set_target_properties(Boost::boost PROPERTIES INTERFACE_COMPILE_OPTIONS "-isystem;${BOOST_SOURCE}"    )
-else()
-  set_target_properties(Boost::boost PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${BOOST_SOURCE}    )
-  set_target_properties(Boost::boost PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${BOOST_SOURCE})
-endif()
+
+target_include_directories(Boost::boost SYSTEM INTERFACE ${BOOST_SOURCE})
 
 # Disable autolink
-set_property(TARGET Boost::boost APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS BOOST_ALL_NO_LIB=1)
+target_compile_definitions(Boost::boost INTERFACE BOOST_ALL_NO_LIB=1)


### PR DESCRIPTION
When using XCode on a project that also contains Swift code, the isystem option is too broadly applied and wrongly used on the Swift code as well. This triggers a `error: unknown argument: '-isystem'
` error.

This patch fixes that and also cleans up some of the CMake commands. Tested on Mac/Linux/Windows.