### PR TITLE
Correct FETCHCONTENT_SOURCE_DIR_boost

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ FetchContent_Declare(
 
 If you have Boost sources already available and want to point to them, you can use the following:
 ```
-set(FETCHCONTENT_SOURCE_DIR_boost /path/to/boost)
+set(FETCHCONTENT_SOURCE_DIR_BOOST /path/to/boost)
 add_subdirectory(boost-cmake)
 ```
 


### PR DESCRIPTION
It should be `FETCHCONTENT_SOURCE_DIR_BOOST`.
The upper-cased **BOOST**, according to CMake FetchContent documentation.