### PR TITLE
Print a message before/after fetching Boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,9 @@ FetchContent_Declare(
 FetchContent_GetProperties(Boost)
 
 if(NOT Boost_POPULATED)
+  message(STATUS "Fetching Boost")
   FetchContent_Populate(Boost)
+  message(STATUS "Fetching Boost - done")
   set(BOOST_SOURCE ${boost_SOURCE_DIR})
 endif()
 


### PR DESCRIPTION
It can take a while to fetch Boost, so it's nice to be told what it's doing (otherwise you might think that CMake is hung).

(Arguably, this should be a part of FetchContent_Populate.... *shrug*)