### PR TITLE
Modified boost source

### DIFF
--- a/repack.sh
+++ b/repack.sh
@@ -14,7 +14,7 @@ patch_dir=$(pwd)/patch/${BOOST_VERSION}
 tmp_dir=$(mktemp -d)
 
 echo "Downloading Boost ${BOOST_VERSION}..."
-curl -L "https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION//\./_}.tar.bz2" > ${tmp_dir}/boost_${BOOST_VERSION}.tar.bz2
+curl -L "https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION//\./_}.tar.bz2" > ${tmp_dir}/boost_${BOOST_VERSION}.tar.bz2
 
 mkdir -p ${tmp_dir}/extract
 cd ${tmp_dir}/extract


### PR DESCRIPTION
The bintray boost source seemed to be deprecated. Updated the boost source with the one on the boost.org website: https://www.boost.org/users/history/version_1_71_0.html